### PR TITLE
fix: 修复calculate 的config的初始化在get_width之前

### DIFF
--- a/Honkai_Star_Rail.py
+++ b/Honkai_Star_Rail.py
@@ -74,6 +74,7 @@ def main(type=0,platform="PC"):
             calculated("PC").switch_window()
             time.sleep(0.5)
             get_width()
+            map_instance.calculated.CONFIG = read_json_file(CONFIG_FILE_NAME)
             import pyautogui # 缩放纠正
             log.info("开始运行，请勿移动鼠标和键盘")
             log.info("若脚本运行无反应,请使用管理员权限运行")


### PR DESCRIPTION
问题: calculate和map一起初始化了, 但此时get_width并未调用, calculate 读取到是init的config, 导致real_width的值为0, 最终在mouse_move中出现 division  by zero 的错误

所以在get_width 后重新读取config