### PR TITLE
地图列表找不到的时候 尝试滚动右方列表寻找

### DIFF
--- a/utils/calculated.py
+++ b/utils/calculated.py
@@ -334,6 +334,7 @@ class calculated:
             else:
                 if type(temp_ocr[temp_name]) == str:
                     start_time = time.time()
+                    first_timeout = True
                     while True:
                         ocr_data = self.part_ocr((77,10,85,97)) if self.platform == _("PC") else self.part_ocr((72,18,80,97))
                         log.debug(temp_ocr[temp_name])
@@ -345,18 +346,42 @@ class calculated:
                             break
                         if time.time() - start_time > 5:
                             log.info(_("地图识别超时"))
+                            # 右边列表太长了 尝试向下滚动5秒 再向上滚动5秒
+                            # scroll内部sleep 0.5s 大概能10次 目前最长在雅利洛需要向下滚动7次
+                            if first_timeout:  # 点击右边的地图列表
+                                self.Relative_click((80, 50) if self.platform == _("PC") else (75, 50), 0.2)
+                                first_timeout = False
+                            if time.time() - start_time < 10:
+                                self.scroll(-10)
+                            else:
+                                self.scroll(10)
+
+                        if time.time() - start_time > 15:
                             join = True
                             break
                 elif type(temp_ocr[temp_name]) == tuple:
                     self.img_click(temp_ocr[temp_name])
         if temp_name not in temp_ocr or join:
             target = cv.imread(target_path)
+            start_time = time.time()
+            first_timeout = True
             while True:
                 result = self.scan_screenshot(target)
                 if result["max_val"] > threshold:
                     #points = self.calculated(result, target.shape)
                     self.Click(result["max_loc"])
                     break
+                if time.time() - start_time > 5:
+                    log.info(_("地图识别超时"))
+                    # 右边列表太长了 尝试向下滚动5秒 再向上滚动5秒
+                    # scroll内部sleep 0.5s 大概能10次 目前最长在雅利洛需要向下滚动7次
+                    if first_timeout:  # 点击右边的地图列表
+                        self.Relative_click((80, 50) if self.platform == _("PC") else (75, 50), 0.2)
+                        first_timeout = False
+                    if time.time() - start_time < 10:
+                        self.scroll(-10)
+                    else:
+                        self.scroll(10)
                 if flag == False:
                     break
 


### PR DESCRIPTION
针对问题：
雅利洛可选地图太多，右方列表无法全部显示。
如果脚本直接选择从 铆钉镇、机械聚落 开始，则无法匹配到这两个地图。

修复方案：
在地图识别超时后，点击右方地图列表，然后进行鼠标滚轮滚动。具体见代码注释。

测试方案：
在任意地图，直接选择从 铆钉镇、机械聚落 开始

其它问题：
scroll方法传入的clicks无效，尝试了1-10都是滚动相同的距离。可能是因为sleep问题，但删除sleep后也不知道是因为连续调用scoll导致一直往下还是clicks生效了。
目前在我的机器上7次可以滚动见到机械聚落，不知道慢点的机器会不会滚不到