### PR TITLE
选择星球时 使用图片匹配兜底

### DIFF
--- a/utils/calculated.py
+++ b/utils/calculated.py
@@ -340,7 +340,9 @@ class calculated:
             elif "map" in temp_name:
                 log.info(_("选择地图"))
             if "map" not in temp_name:
-                self.ocr_click(temp_ocr[temp_name])
+                success = self.ocr_click(temp_ocr[temp_name])
+                if not success:
+                    join = True
                 while True:
                     if not self.is_blackscreen():
                         break


### PR DESCRIPTION
在雅利洛时，出现ocr没法扫描到 "星轨航图" 的情况，看了下OCR部分没搞懂为什么，就在这里多加一个用图片匹配的兜底解决