### PR TITLE
缩小右侧地图选择框 避免点击到星轨航图

### DIFF
--- a/utils/calculated.py
+++ b/utils/calculated.py
@@ -384,7 +384,7 @@ class calculated:
                     start_time = time.time()
                     first_timeout = True
                     while True:
-                        ocr_data = self.part_ocr((77,10,85,97)) if self.platform == _("PC") else self.part_ocr((72,18,80,97))
+                        ocr_data = self.part_ocr((77,20,85,97)) if self.platform == _("PC") else self.part_ocr((72,18,80,97))
                         log.debug(temp_ocr[temp_name])
                         check_dict = list(filter(lambda x: re.match(f'.*{temp_ocr[temp_name]}.*', x) != None, list(ocr_data.keys())))
                         pos = ocr_data.get(check_dict[0], None) if check_dict else None


### PR DESCRIPTION
雅利洛地图，右侧出现滚动时（例如人在机械聚落）
如果第一个选项只出现了部分（例如要往上滚动前往）
会出现点击到“星轨航图“情况

实测发现，虽然"星轨航图"的横条很窄，但实际可点击区域跟下方的选项是一样宽的。

所以把OCR部分往下裁剪了一点，出来的图片依然是能包含完整的右侧列表的