### PR TITLE
修复副屏幕截图为为黑屏的问题

### DIFF
--- a/utils/calculated.py
+++ b/utils/calculated.py
@@ -215,7 +215,7 @@ class calculated:
             left, top, right, bottom = self.window.left, self.window.top, self.window.right, self.window.bottom
         else:
             left, top, right, bottom = self.window.left+left_border, self.window.top+up_border, self.window.right-left_border, self.window.bottom-left_border
-        temp = ImageGrab.grab((left, top, right, bottom))
+        temp = ImageGrab.grab((left, top, right, bottom), all_screens=True)
         width, length = temp.size           
         if points != (0,0,0,0):
             #points = (points[0], points[1]+5, points[2], points[3]+5)

--- a/utils/cv_tools.py
+++ b/utils/cv_tools.py
@@ -49,7 +49,7 @@ def take_screenshot(rect, platform="PC", order="127.0.0.1:62001", adb_path="temp
         left, top, right, bottom = window.left, window.top, window.right, window.bottom
         #temp = pyautogui.screenshot(region=rect1)
         #print((rect[0],rect[1],rect[3],rect[2]))
-        temp = ImageGrab.grab((rect[0]+left,rect[1]+top,rect[3]+left,rect[2]+top))
+        temp = ImageGrab.grab((rect[0]+left,rect[1]+top,rect[3]+left,rect[2]+top), all_screens=True)
     elif platform == "模拟器":
         os.system(f"{adb_path} -s {order} shell screencap -p /sdcard/Pictures/screencast.png")
         os.system(f"{adb_path} -s {order} pull /sdcard/Pictures/screencast.png")

--- a/utils/record_v7.2.py
+++ b/utils/record_v7.2.py
@@ -152,7 +152,7 @@ def take_screenshot(points=(0,0,0,0)):
         left, top, right, bottom = window.left, window.top, window.right, window.bottom
     else:
         left, top, right, bottom = window.left+left_border, window.top+up_border, window.right-left_border, window.bottom-left_border
-    temp = ImageGrab.grab((left, top, right, bottom))
+    temp = ImageGrab.grab((left, top, right, bottom), all_screens=True)
     width, length = temp.size
     if points != (0,0,0,0):
         #points = (points[0], points[1]+5, points[2], points[3]+5) if self.platform == _("PC") else points

--- a/utils/simulated_universe.py
+++ b/utils/simulated_universe.py
@@ -78,7 +78,7 @@ class Simulated_Universe:
         start_time = time.time()
         while True:
             left, top, right, bottom = self.window.left, self.window.top, self.window.right, self.window.bottom
-            img_fp = ImageGrab.grab((left, top, right, bottom))
+            img_fp = ImageGrab.grab((left, top, right, bottom), all_screens=True)
             text, pos = self.calculated.ocr_pos(img_fp, _("下载初始角色"))
             if pos:
                 self.calculated.Click((left+pos[0], top+pos[1]))
@@ -96,7 +96,7 @@ class Simulated_Universe:
         """
         time.sleep(1)
         left, top, right, bottom = self.window.left, self.window.top, self.window.right, self.window.bottom
-        img_fp = ImageGrab.grab((left, top, right-(right-left)/100*70, bottom))
+        img_fp = ImageGrab.grab((left, top, right-(right-left)/100*70, bottom), all_screens=True)
         start_time = time.time()
         while True:
             for role in roles:


### PR DESCRIPTION
发现 `ImageGrab.grab()` 的 `all_screens` 参数设置为 `True` 即可解决这个问题
```python
window = gw.getWindowsWithTitle('notepad')[0]

left, top, right, bottom = window.left, window.top, window.right, window.bottom

im = ImageGrab.grab(bbox=(left, top, right, bottom), all_screens=False)
im.show('old')

im = ImageGrab.grab(bbox=(left, top, right, bottom), all_screens=True)
im.show('new')

```

但是计算缩放比例等接口仍然有多屏幕适配的问题，暂时没有找到解决办法