### PR TITLE
fix: 修复游戏1.5版本地图传送提前判定成功的问题

### DIFF
--- a/utils/calculated.py
+++ b/utils/calculated.py
@@ -829,6 +829,7 @@ class calculated(CV_Tools):
             进入地图的时间
         """
         start_time = time.time()
+        time.sleep(2.0)   # 1.5版本点击传送后，会先返回到原地图页面再进入传送
         '''
         join1 = False
         join2 = False


### PR DESCRIPTION
游戏1.5版本点击传送后，会先返回到原地图页面再进入传送，导致原代码提前判定传送成功