### PR TITLE
fix: gui.py, 22行错误

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ tqdm
 ultralytics
 xpinyin
 httpx_socks
-flet==0.24.1
+flet==0.23.2
 cryptography
 pluggy
 httpcore

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ tqdm
 ultralytics
 xpinyin
 httpx_socks
-flet
+flet==0.24.1
 cryptography
 pluggy
 httpcore


### PR DESCRIPTION
flet 0.25.0 以后 flet_core被合并了, 详见: https://github.com/flet-dev/flet/commit/cc998cd52f0c463c92343ea0ce1820bd0c5ea88d